### PR TITLE
Create NovaStack landing site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,897 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NovaStack Platform | Software Intelligence Suite</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-gradient: linear-gradient(135deg, #0b1526, #202c54, #5c2a82);
+      --card-bg: rgba(19, 32, 56, 0.65);
+      --accent: #9f7afa;
+      --accent-strong: #fba740;
+      --text-primary: #f6f8ff;
+      --text-secondary: #c5c9e6;
+      --border-glow: rgba(159, 122, 250, 0.4);
+      --shadow-strong: 0 24px 60px rgba(15, 23, 42, 0.45);
+      --shadow-soft: 0 18px 36px rgba(15, 23, 42, 0.35);
+      --max-width: 1200px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg-gradient);
+      background-attachment: fixed;
+      color: var(--text-primary);
+      min-height: 100%;
+      scroll-behavior: smooth;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at 20% 20%, rgba(159, 122, 250, 0.18), transparent 45%),
+                  radial-gradient(circle at 80% 10%, rgba(251, 167, 64, 0.16), transparent 50%),
+                  radial-gradient(circle at 50% 70%, rgba(69, 191, 255, 0.12), transparent 55%);
+      z-index: -2;
+    }
+
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: url('data:image/svg+xml,%3Csvg width="1200" height="800" viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="none" fill-opacity="0.05" stroke="%23ffffff" stroke-width="0.5"%3E%3Cpath d="M0 400 Q 300 320 600 400 T 1200 400"/%3E%3Cpath d="M0 500 Q 320 420 640 500 T 1280 500"/%3E%3Cpath d="M0 600 Q 340 520 680 600 T 1360 600"/%3E%3C/g%3E%3C/svg%3E');
+      background-size: cover;
+      mix-blend-mode: screen;
+      opacity: 0.35;
+      z-index: -3;
+      animation: drift 40s linear infinite;
+    }
+
+    @keyframes drift {
+      0% {
+        transform: translateY(0px) scale(1);
+      }
+      50% {
+        transform: translateY(-25px) scale(1.02);
+      }
+      100% {
+        transform: translateY(0px) scale(1);
+      }
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 99;
+      background: rgba(9, 15, 28, 0.75);
+      backdrop-filter: blur(18px);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    nav {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 1.2rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 2rem;
+    }
+
+    nav .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-family: 'Space Grotesk', sans-serif;
+      letter-spacing: 0.04em;
+    }
+
+    .brand .logo {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(159, 122, 250, 0.75) 40%, rgba(21, 32, 52, 0.9));
+      box-shadow: 0 0 30px rgba(159, 122, 250, 0.6);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .brand .logo::after {
+      content: "";
+      position: absolute;
+      inset: 6px;
+      border-radius: 50%;
+      border: 2px solid rgba(255, 255, 255, 0.6);
+      filter: blur(1px);
+    }
+
+    nav ul {
+      display: flex;
+      list-style: none;
+      gap: 1.5rem;
+      margin: 0;
+      padding: 0;
+    }
+
+    nav a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 0.95rem;
+      transition: color 0.2s ease, opacity 0.2s ease;
+    }
+
+    nav a:hover {
+      color: var(--accent);
+      opacity: 1;
+    }
+
+    .nav-cta {
+      background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+      color: #0b1526;
+      padding: 0.65rem 1.4rem;
+      border-radius: 999px;
+      font-weight: 700;
+      box-shadow: 0 10px 25px rgba(159, 122, 250, 0.4);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .nav-cta:hover {
+      transform: translateY(-2px) scale(1.02);
+      box-shadow: 0 14px 30px rgba(159, 122, 250, 0.55);
+    }
+
+    main {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 0 2rem 6rem;
+    }
+
+    .hero {
+      padding: 5rem 0 4rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 3rem;
+      align-items: center;
+    }
+
+    .hero-content h1 {
+      font-size: clamp(2.8rem, 5vw, 4rem);
+      margin: 0 0 1.5rem;
+      letter-spacing: -0.01em;
+      font-family: 'Space Grotesk', sans-serif;
+      line-height: 1.05;
+    }
+
+    .accent {
+      color: var(--accent-strong);
+    }
+
+    .hero-content p {
+      color: var(--text-secondary);
+      font-size: 1.1rem;
+      line-height: 1.7;
+      max-width: 38ch;
+      margin-bottom: 2.2rem;
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
+    }
+
+    .primary-btn,
+    .secondary-btn {
+      text-decoration: none;
+      padding: 0.8rem 1.8rem;
+      border-radius: 999px;
+      font-weight: 600;
+      border: 1px solid transparent;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+    }
+
+    .primary-btn {
+      background: linear-gradient(135deg, var(--accent), #62d3ff);
+      color: #0b1526;
+      box-shadow: 0 16px 32px rgba(70, 213, 255, 0.25);
+    }
+
+    .primary-btn:hover {
+      transform: translateY(-3px) scale(1.02);
+      box-shadow: 0 24px 42px rgba(70, 213, 255, 0.35);
+    }
+
+    .secondary-btn {
+      background: rgba(255, 255, 255, 0.05);
+      border-color: rgba(255, 255, 255, 0.12);
+      color: var(--text-primary);
+      backdrop-filter: blur(6px);
+    }
+
+    .secondary-btn:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent);
+    }
+
+    .hero-card {
+      background: var(--card-bg);
+      padding: 2.5rem;
+      border-radius: 28px;
+      border: 1px solid rgba(159, 122, 250, 0.2);
+      box-shadow: var(--shadow-strong);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-card::before {
+      content: "";
+      position: absolute;
+      inset: -40% -20% auto auto;
+      width: 240px;
+      height: 240px;
+      background: radial-gradient(circle, rgba(159, 122, 250, 0.5), transparent 70%);
+      filter: blur(18px);
+      opacity: 0.8;
+    }
+
+    .hero-card h2 {
+      margin: 0 0 1.2rem;
+      font-size: 1.6rem;
+      font-family: 'Space Grotesk', sans-serif;
+    }
+
+    .hero-highlight {
+      display: grid;
+      gap: 1.2rem;
+    }
+
+    .hero-highlight li {
+      list-style: none;
+      background: rgba(255, 255, 255, 0.06);
+      padding: 1.1rem 1.25rem;
+      border-radius: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.07);
+      display: flex;
+      gap: 1rem;
+      align-items: flex-start;
+      transition: transform 0.2s ease, border 0.2s ease;
+    }
+
+    .hero-highlight li:hover {
+      transform: translateX(6px);
+      border-color: var(--accent);
+    }
+
+    .hero-highlight span {
+      font-size: 1.8rem;
+      line-height: 1;
+    }
+
+    .section {
+      margin-top: 5rem;
+      padding-top: 2rem;
+    }
+
+    .section-title {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
+
+    .section-lead {
+      color: var(--text-secondary);
+      margin-bottom: 2.5rem;
+      max-width: 60ch;
+      line-height: 1.7;
+    }
+
+    .grid {
+      display: grid;
+      gap: 1.8rem;
+    }
+
+    .grid-3 {
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .grid-2 {
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 22px;
+      padding: 2rem;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: var(--shadow-soft);
+      transition: transform 0.25s ease, border 0.25s ease, box-shadow 0.25s ease;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .card::after {
+      content: "";
+      position: absolute;
+      inset: auto -20% -20% auto;
+      width: 180px;
+      height: 180px;
+      background: radial-gradient(circle, rgba(251, 167, 64, 0.35), transparent 65%);
+      opacity: 0;
+      transition: opacity 0.25s ease;
+    }
+
+    .card:hover {
+      transform: translateY(-8px);
+      border-color: rgba(159, 122, 250, 0.45);
+      box-shadow: 0 24px 40px rgba(9, 15, 28, 0.6);
+    }
+
+    .card:hover::after {
+      opacity: 1;
+    }
+
+    .card h3 {
+      margin-top: 0;
+      font-size: 1.3rem;
+      font-family: 'Space Grotesk', sans-serif;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: rgba(255, 255, 255, 0.08);
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 1.5rem;
+      color: var(--text-secondary);
+    }
+
+    .insights {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+      margin-top: 2rem;
+    }
+
+    .insight {
+      background: rgba(255, 255, 255, 0.04);
+      border-radius: 18px;
+      padding: 1.25rem;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .insight strong {
+      font-size: 1.8rem;
+      display: block;
+      margin-bottom: 0.5rem;
+      color: #8ed9ff;
+    }
+
+    .timeline {
+      position: relative;
+      margin-top: 3rem;
+      padding-left: 1rem;
+    }
+
+    .timeline::before {
+      content: "";
+      position: absolute;
+      left: 18px;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: linear-gradient(to bottom, rgba(159, 122, 250, 0.1), rgba(159, 122, 250, 0.7));
+    }
+
+    .timeline-step {
+      position: relative;
+      padding: 1.5rem 1.5rem 1.5rem 3.5rem;
+      background: rgba(255, 255, 255, 0.03);
+      border-radius: 18px;
+      margin-bottom: 1.5rem;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      transition: transform 0.2s ease;
+    }
+
+    .timeline-step:hover {
+      transform: translateX(6px);
+    }
+
+    .timeline-step::before {
+      content: attr(data-step);
+      position: absolute;
+      left: -5px;
+      top: 18px;
+      width: 40px;
+      height: 40px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, var(--accent), #62d3ff);
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      color: #0b1526;
+      box-shadow: 0 10px 20px rgba(159, 122, 250, 0.3);
+    }
+
+    .code-frame {
+      background: rgba(4, 9, 21, 0.75);
+      border-radius: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      padding: 2rem;
+      font-family: 'Space Grotesk', monospace;
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: #d5e2ff;
+      position: relative;
+      overflow: hidden;
+      box-shadow: var(--shadow-soft);
+    }
+
+    .code-frame::before {
+      content: "NovaStack.yaml";
+      position: absolute;
+      top: 0.75rem;
+      left: 1.2rem;
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .code-line span {
+      color: #6cf0ff;
+    }
+
+    table.resources {
+      width: 100%;
+      border-collapse: collapse;
+      background: rgba(4, 8, 19, 0.85);
+      border-radius: 20px;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      box-shadow: var(--shadow-soft);
+    }
+
+    table.resources thead {
+      background: rgba(255, 255, 255, 0.04);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    table.resources th,
+    table.resources td {
+      padding: 1.1rem 1.4rem;
+      text-align: left;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    }
+
+    table.resources tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    table.resources a {
+      color: #8ed9ff;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    table.resources a:hover {
+      text-decoration: underline;
+    }
+
+    .cta {
+      margin-top: 5rem;
+      padding: 3rem;
+      border-radius: 26px;
+      background: linear-gradient(135deg, rgba(4, 14, 32, 0.9), rgba(18, 38, 68, 0.75));
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 2rem;
+      align-items: center;
+      box-shadow: var(--shadow-strong);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .cta::after {
+      content: "";
+      position: absolute;
+      inset: -30% auto auto -20%;
+      width: 320px;
+      height: 320px;
+      background: radial-gradient(circle, rgba(159, 122, 250, 0.35), transparent 70%);
+      opacity: 0.6;
+      filter: blur(10px);
+    }
+
+    .cta h3 {
+      font-size: 1.8rem;
+      margin-bottom: 1rem;
+      font-family: 'Space Grotesk', sans-serif;
+    }
+
+    footer {
+      margin-top: 5rem;
+      padding: 2rem 0 3rem;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    footer .footer-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 2rem;
+    }
+
+    .footer-grid h4 {
+      margin-top: 0;
+      font-family: 'Space Grotesk', sans-serif;
+      color: var(--text-primary);
+    }
+
+    .footer-links {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.6rem;
+    }
+
+    .footer-links a {
+      color: var(--text-secondary);
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    .footer-links a:hover {
+      color: var(--accent);
+    }
+
+    .badge-group {
+      display: flex;
+      gap: 0.8rem;
+      flex-wrap: wrap;
+      margin-top: 1rem;
+    }
+
+    .badge {
+      background: rgba(255, 255, 255, 0.06);
+      border-radius: 999px;
+      padding: 0.5rem 1rem;
+      font-size: 0.8rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    @media (max-width: 720px) {
+      nav {
+        padding: 1rem 1.5rem;
+      }
+
+      nav ul {
+        display: none;
+      }
+
+      .hero {
+        padding-top: 3.5rem;
+      }
+
+      main {
+        padding: 0 1.5rem 4rem;
+      }
+
+      .code-frame {
+        font-size: 0.85rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav>
+      <div class="brand">
+        <div class="logo"></div>
+        <div>
+          <strong>NOVASTACK</strong><br>
+          <small>Software Intelligence Platform</small>
+        </div>
+      </div>
+      <ul>
+        <li><a href="#overview">Overview</a></li>
+        <li><a href="#architecture">Architecture</a></li>
+        <li><a href="#modules">Modules</a></li>
+        <li><a href="#resources">Resources</a></li>
+        <li><a href="#timeline">Roadmap</a></li>
+      </ul>
+      <a class="nav-cta" href="#contact">Join the Beta</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero" id="overview">
+      <div class="hero-content">
+        <div class="pill">Version 2.4 • Now shipping adaptive insight pipelines</div>
+        <h1>Build, observe, and evolve software with <span class="accent">NovaStack</span>.</h1>
+        <p>NovaStack brings together code intelligence, workflow automation, and operational analytics into one cohesive experience—so product teams can iterate at the speed of thought while staying in control.</p>
+        <div class="hero-actions">
+          <a class="primary-btn" href="#resources">Explore the Suite</a>
+          <a class="secondary-btn" href="#contact">Book a Strategy Call</a>
+        </div>
+        <div class="insights">
+          <div class="insight">
+            <strong>98%</strong>
+            Release stability across 4k deployments
+          </div>
+          <div class="insight">
+            <strong>12x</strong>
+            Faster signal-to-action for critical incidents
+          </div>
+          <div class="insight">
+            <strong>46</strong>
+            Curated integrations and automation blueprints
+          </div>
+        </div>
+      </div>
+
+      <aside class="hero-card">
+        <h2>Unified delivery loop</h2>
+        <ul class="hero-highlight">
+          <li>
+            <span>🚀</span>
+            <div>
+              <strong>Adaptive release cadences</strong>
+              <p>Launch with confidence using predictive impact scoring and automated guardrails.</p>
+            </div>
+          </li>
+          <li>
+            <span>🧠</span>
+            <div>
+              <strong>Insight orchestration</strong>
+              <p>Blend machine learning signals with human review, all in one command center.</p>
+            </div>
+          </li>
+          <li>
+            <span>🛰️</span>
+            <div>
+              <strong>Always-on observability</strong>
+              <p>Stream telemetry, trace dependencies, and surface anomalies before they impact users.</p>
+            </div>
+          </li>
+        </ul>
+      </aside>
+    </section>
+
+    <section class="section" id="architecture">
+      <div class="pill">Platform anatomy</div>
+      <h2 class="section-title">An architecture designed for clarity and velocity</h2>
+      <p class="section-lead">NovaStack wraps every layer—from commit to cloud—in a progressive data mesh that makes insight a first-class primitive. The stack is modular yet deeply integrated, giving teams a shared source of truth and the tools to automate anything.</p>
+      <div class="grid grid-2">
+        <div class="card">
+          <h3>Insight Fabric</h3>
+          <p>Event-driven data fabric that normalizes telemetry across Git, CI, runtime metrics, and customer feedback. Enriched context powers every automation and dashboard.</p>
+        </div>
+        <div class="card">
+          <h3>Action Engine</h3>
+          <p>Composable automation engine with policy-as-code, AI copilots, and human approval flows. Integrates with 120+ SaaS and infrastructure providers.</p>
+        </div>
+        <div class="card">
+          <h3>Experience Canvas</h3>
+          <p>Unified workspace for engineering, product, and reliability. Share live roadmaps, architecture decisions, incident retrospectives, and executive scorecards.</p>
+        </div>
+        <div class="card">
+          <h3>Trust Layer</h3>
+          <p>Granular controls, compliance-ready audit trails, and encrypted data enclaves keep enterprise teams safe without slowing them down.</p>
+        </div>
+      </div>
+
+      <div class="section" style="margin-top: 3rem;">
+        <div class="grid grid-2" style="align-items: stretch; gap: 2.5rem;">
+          <div class="code-frame">
+            <div class="code-line"><span>pipeline:</span> delivery-insights</div>
+            <div class="code-line">  ingest:</div>
+            <div class="code-line">    - source: github</div>
+            <div class="code-line">      watch: nova/**</div>
+            <div class="code-line">      enrich: commits, pr_reviews</div>
+            <div class="code-line">    - source: kubernetes</div>
+            <div class="code-line">      cluster: prod-eu-1</div>
+            <div class="code-line">      metrics: latency_p95, error_rate</div>
+            <div class="code-line">  orchestrate:</div>
+            <div class="code-line">    - trigger: deploy</div>
+            <div class="code-line">      policy: adaptive-rollout</div>
+            <div class="code-line">      action: progressive_delivery</div>
+            <div class="code-line">    - trigger: anomaly %3E 3σ</div>
+            <div class="code-line">      action: open_incident</div>
+            <div class="code-line">      notify: reliability@novastack.dev</div>
+            <div class="code-line">  surface:</div>
+            <div class="code-line">    - board: mission_control</div>
+            <div class="code-line">      widgets: release_heatmap, flow_efficiency, posture</div>
+          </div>
+          <div>
+            <h3 style="font-family: 'Space Grotesk', sans-serif; font-size: 1.6rem;">Operating system for modern delivery</h3>
+            <p style="color: var(--text-secondary); line-height: 1.7;">Every NovaStack workspace ships with best-practice automations, curated dashboards, and governance templates. Teams can tailor everything with our declarative DSL or via drag-and-drop builders, knowing every change is versioned and reviewable.</p>
+            <div class="badge-group">
+              <div class="badge">SOC 2 Type II</div>
+              <div class="badge">GDPR Ready</div>
+              <div class="badge">ISO 27001</div>
+              <div class="badge">99.99% SLA</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="modules">
+      <div class="pill">Suite modules</div>
+      <h2 class="section-title">Everything your software organization needs—beautifully orchestrated</h2>
+      <p class="section-lead">Crafted with design systems thinking, each NovaStack module amplifies a mission-critical discipline. Pick what you need today, expand tomorrow.</p>
+      <div class="grid grid-3">
+        <div class="card">
+          <h3>Velocity Lab</h3>
+          <p>Plan sprints, model delivery risk, and simulate throughput scenarios with AI-assisted planners that learn from every iteration.</p>
+        </div>
+        <div class="card">
+          <h3>Quality Observatory</h3>
+          <p>Holistic view across unit tests, chaos drills, UX telemetry, and customer sentiment to safeguard every release.</p>
+        </div>
+        <div class="card">
+          <h3>Reliability Command</h3>
+          <p>Automated on-call runbooks, incident storytelling, postmortem builders, and resilience scoring in one command center.</p>
+        </div>
+        <div class="card">
+          <h3>Product Pulse</h3>
+          <p>Align product intent with delivery reality using OKR progressions, feature adoption curves, and north-star dashboards.</p>
+        </div>
+        <div class="card">
+          <h3>Integration Nexus</h3>
+          <p>Marketplace of curated connectors with policy-aware routing. Deploy new automations in minutes, not months.</p>
+        </div>
+        <div class="card">
+          <h3>Executive Brief</h3>
+          <p>Executive-ready briefings with interactive storytelling and dynamic scenario planning for board meetings and strategic reviews.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="timeline">
+      <div class="pill">Roadmap</div>
+      <h2 class="section-title">NovaStack launch trajectory</h2>
+      <p class="section-lead">We're iterating in the open with our design partners. Here's how the platform will evolve over the next 12 months.</p>
+      <div class="timeline">
+        <div class="timeline-step" data-step="Q2">
+          <h3>Mission Control 2.0</h3>
+          <p>Unified experience updates, new automation blueprints, and multi-tenant workspaces.</p>
+        </div>
+        <div class="timeline-step" data-step="Q3">
+          <h3>Autonomous Insights</h3>
+          <p>AI copilots for incident retrospectives, release gating, and feature prioritization.</p>
+        </div>
+        <div class="timeline-step" data-step="Q4">
+          <h3>Global Scale Mesh</h3>
+          <p>Edge collectors, private data plane, and sovereign deployment options.</p>
+        </div>
+        <div class="timeline-step" data-step="Q1">
+          <h3>Marketplace Expansion</h3>
+          <p>Third-party extensions, design tokens for UI customization, and partner analytics.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="resources">
+      <div class="pill">Resource directory</div>
+      <h2 class="section-title">Every artifact, one command center</h2>
+      <p class="section-lead">Use this resource matrix to explore documentation, demos, automation kits, and strategic guidance that help teams adopt NovaStack.</p>
+      <table class="resources">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Description</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Launch Guide</td>
+            <td>Step-by-step blueprint to roll out NovaStack across delivery, quality, and reliability teams.</td>
+            <td><a href="#">Download playbook</a></td>
+          </tr>
+          <tr>
+            <td>Design System</td>
+            <td>Figma design kits, component guidelines, and accessibility best practices.</td>
+            <td><a href="#">Open in Figma</a></td>
+          </tr>
+          <tr>
+            <td>API Reference</td>
+            <td>GraphQL and REST endpoints for automation, reporting, and integration extensions.</td>
+            <td><a href="#">Explore API</a></td>
+          </tr>
+          <tr>
+            <td>Automation Library</td>
+            <td>Pre-built workflows for CI/CD, incident response, and compliance reporting.</td>
+            <td><a href="#">Browse automations</a></td>
+          </tr>
+          <tr>
+            <td>Partner Enablement</td>
+            <td>Decks, ROI calculators, and deployment playbooks for solution partners.</td>
+            <td><a href="#">Access portal</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section" id="contact">
+      <div class="pill">Ready to explore?</div>
+      <div class="cta">
+        <div>
+          <h3>Design the future of software operations</h3>
+          <p style="color: var(--text-secondary); line-height: 1.8;">Join the NovaStack pioneer program and co-create the next wave of intelligent delivery with our product strategists and design partners.</p>
+        </div>
+        <div>
+          <form style="display: grid; gap: 1rem;">
+            <input type="text" name="name" placeholder="Full name" required style="padding: 0.9rem 1.2rem; border-radius: 14px; border: 1px solid rgba(255, 255, 255, 0.12); background: rgba(5, 12, 24, 0.8); color: var(--text-primary);">
+            <input type="email" name="email" placeholder="Work email" required style="padding: 0.9rem 1.2rem; border-radius: 14px; border: 1px solid rgba(255, 255, 255, 0.12); background: rgba(5, 12, 24, 0.8); color: var(--text-primary);">
+            <textarea name="notes" rows="3" placeholder="Tell us about your goals" style="padding: 0.9rem 1.2rem; border-radius: 14px; border: 1px solid rgba(255, 255, 255, 0.12); background: rgba(5, 12, 24, 0.8); color: var(--text-primary); resize: vertical;"></textarea>
+            <button type="submit" class="primary-btn" style="border: none; cursor: pointer; justify-self: flex-start;">Request Invite</button>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-grid">
+      <div>
+        <h4>NovaStack</h4>
+        <p>Built by makers, operators, and dreamers to reimagine how software ships at scale.</p>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <ul class="footer-links">
+          <li><a href="#">About</a></li>
+          <li><a href="#">Careers</a></li>
+          <li><a href="#">Press</a></li>
+          <li><a href="#">Legal</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Connect</h4>
+        <ul class="footer-links">
+          <li><a href="#">Product Updates</a></li>
+          <li><a href="#">Design Community</a></li>
+          <li><a href="#">Partner Program</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Platform</h4>
+        <ul class="footer-links">
+          <li><a href="#overview">Platform Overview</a></li>
+          <li><a href="#modules">Module Suite</a></li>
+          <li><a href="#resources">Resource Directory</a></li>
+        </ul>
+      </div>
+    </div>
+    <p style="margin-top: 2rem; text-align: center;">© 2024 NovaStack Labs. Crafted with intention for teams who think beyond the sprint.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an immersive NovaStack landing page with animated gradient background, sticky navigation, and hero call-to-actions
- highlight platform architecture, module suite, roadmap timeline, and resource directory using glassmorphism cards
- include invite-focused contact section, metrics highlights, and refined footer links for quick orientation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf3556aff083289467a3881d94e881